### PR TITLE
MP - change description of primary_laser_wavelength and schema version, convert and validate

### DIFF
--- a/metadata_examples/MP.json
+++ b/metadata_examples/MP.json
@@ -315,7 +315,7 @@
         ]
       },
       "method_specific_parameters": {
-        "schema_version": "1.0.0",
+        "schema_version": "1.0.1",
         "primary_laser_wavelength": {
           "value": 525,
           "unit": "nm"

--- a/metadata_examples/MP.yaml
+++ b/metadata_examples/MP.yaml
@@ -232,7 +232,7 @@ general_parameters:
           unit: 'nm'
 
 method_specific_parameters:
-    schema_version: '1.0.0'
+    schema_version: '1.0.1'
 
     primary_laser_wavelength:
         value: 525

--- a/models/main/MP.yaml
+++ b/models/main/MP.yaml
@@ -20,10 +20,10 @@ MP_specific_parameters:
         description     : str(equals='The schema version used to annotate the
                                       MP method specific parameters',
                               required=False)
-        value           : keyword(equals='1.0.0')
+        value           : keyword(equals='1.0.1')
 
     primary_laser_wavelength:
-        description     : str(equals='The primary illumination laser wavelength used in the experiment',
+        description     : str(equals='Wavelength of the laser used for measurement of the mass photometry signal',
                                 required=False)
         value           : include('Wavelength', required=False)
 

--- a/models/oarepo/mp-definitions.yaml
+++ b/models/oarepo/mp-definitions.yaml
@@ -3,13 +3,14 @@ MP_specific_parameters:
     schema_version:
       type: keyword
       enum:
-        - 1.0.0
+        - 1.0.1
       help.en: The schema version used to annotate the MP method specific 
         parameters
       required: true
       label.en: Schema version
     primary_laser_wavelength:
-      help.en: The primary illumination laser wavelength used in the experiment
+      help.en: Wavelength of the laser used for measurement of the mass 
+        photometry signal
       label.en: Primary laser wavelength
       use: '#/$defs/Wavelength'
     calibrants[]:

--- a/models/unrolled/MP.txt
+++ b/models/unrolled/MP.txt
@@ -279,7 +279,7 @@
 "  |    |   unit                                                                             ('singular', 'optional', ['Enum'], {}) "
 "  |    |   size_type                                                                        ('singular', 'required', ['Enum'], {}) "
 " method_specific_parameters                                                                 ('singular', 'required', ['dict'], {}) "
-"  |   schema_version                                                                        ('singular', 'required', ['Keyword'], {'equals': '1.0.0'}) "
+"  |   schema_version                                                                        ('singular', 'required', ['Keyword'], {'equals': '1.0.1'}) "
 "  |   primary_laser_wavelength                                                              ('singular', 'required', ['dict'], {}) "
 "  |    |   value                                                                            ('singular', 'required', ['Number'], {'min': 0}) "
 "  |    |   unit                                                                             ('singular', 'optional', ['Enum'], {}) "

--- a/models/values-only/MP.yaml
+++ b/models/values-only/MP.yaml
@@ -2,7 +2,7 @@ general_parameters: include('General_parameters')
 method_specific_parameters: include('MP_specific_parameters')
 ---
 MP_specific_parameters:
-  schema_version: keyword(equals='1.0.0')
+  schema_version: keyword(equals='1.0.1')
   primary_laser_wavelength: include('Wavelength', required=False)
   calibrants: list(include("Calibrant"))
   mode: include('MP_mode')


### PR DESCRIPTION
MP: primary_laser_wavelength description changed to a better definition and to fit tooltip in the input form, schema version changed, converted and validated. 